### PR TITLE
Compilation fix for Ubuntu 24.04 LTS

### DIFF
--- a/include/rosx_introspection/serializer.hpp
+++ b/include/rosx_introspection/serializer.hpp
@@ -3,7 +3,7 @@
 // API adapted to FastCDR
 
 #include <exception>
-
+#include <vector>
 #include "rosx_introspection/builtin_types.hpp"
 #include "rosx_introspection/variant.hpp"
 


### PR DESCRIPTION
```bash
colcon build # Is throwing this error
``` 


![rosx_error_24](https://github.com/facontidavide/rosx_introspection/assets/23361336/94849beb-a4f2-42e1-a312-5a8cb4f16e7a)

Fixed compilation issue for "Ubuntu 24.04 LTS"
