### PR TITLE
Fix ros_parser.cpp compilation failures on Clang

### DIFF
--- a/src/ros_parser.cpp
+++ b/src/ros_parser.cpp
@@ -581,8 +581,7 @@ bool Parser::serializeFromJson(const std::string_view json_string,
             }
             else
             {
-              rapidjson::Value next_value = value_field->GetObject();
-              serializeImpl(msg_node_child.get(), &next_value);
+              serializeImpl(msg_node_child.get(), value_field);
             }
           }
           break;
@@ -600,7 +599,7 @@ bool Parser::serializeFromJson(const std::string_view json_string,
   auto root_msg =
       _schema->field_tree.croot()->value()->getMessagePtr(_schema->msg_library);
 
-  rapidjson::Value json_root = json_document.GetObject();
+  rapidjson::Value& json_root = json_document;
   serializeImpl(root_msg.get(), &json_root);
 
   return true;


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/24740

Caveat: I'm not familiar with rapidjson at all. The `test_parser` test built and ran without issues, though.