### PR TITLE
Add missing include of functional header in message_definition_cache.cpp

### DIFF
--- a/src/ros_utils/message_definition_cache.cpp
+++ b/src/ros_utils/message_definition_cache.cpp
@@ -19,6 +19,7 @@
 #include <ament_index_cpp/get_resources.hpp>
 
 #include <fstream>
+#include <functional>
 #include <regex>
 #include <set>
 #include <string>


### PR DESCRIPTION
message_definition_cache.cpp uses std::function, so it should include the functional STL header