### PR TITLE
fix compilation errors on mac

### DIFF
--- a/include/rosx_introspection/contrib/nanocdr.hpp
+++ b/include/rosx_introspection/contrib/nanocdr.hpp
@@ -121,7 +121,7 @@ enum class Endianness : uint8_t
   CDR_LITTLE_ENDIAN = 0x01
 };
 
-constexpr Endianness getCurrentEndianness();
+inline Endianness getCurrentEndianness();
 
 template <typename T>
 inline void swapEndianness(T& val);
@@ -323,7 +323,7 @@ constexpr bool is_type_defined_v()
   return is_type_defined<T>::value;
 }
 
-constexpr Endianness getCurrentEndianness()
+inline Endianness getCurrentEndianness()
 {
   union
   {

--- a/include/rosx_introspection/contrib/span.hpp
+++ b/include/rosx_introspection/contrib/span.hpp
@@ -826,7 +826,7 @@ span_noreturn inline void throw_out_of_range( size_t idx, size_t size )
 {
     const char fmt[] = "span::at(): index '%lli' is out of range [0..%lli)";
     char buffer[ 2 * 20 + sizeof fmt ];
-    sprintf( buffer, fmt, static_cast<long long>(idx), static_cast<long long>(size) );
+    snprintf( buffer, sizeof(buffer), fmt, static_cast<long long>(idx), static_cast<long long>(size) );
 
     throw std::out_of_range( buffer );
 }

--- a/include/rosx_introspection/stringtree_leaf.hpp
+++ b/include/rosx_introspection/stringtree_leaf.hpp
@@ -52,7 +52,7 @@ inline int print_number(char* buffer, uint16_t value) {
     buffer[1] = DIGITS[value + 1];
     return 2;
   } else {
-    return sprintf(buffer, "%d", value);
+    return snprintf(buffer, 16, "%d", value);
   }
 }
 


### PR DESCRIPTION
compilation on mac using AppleClang 17.0.0 was failing due to more aggressive checking of `constexpr`.  While I was at it, I also upgraded two uses of `sprintf` to `snprintf` to get rid of warnings.