### PR TITLE
Add sensor_msgs, geometry_msgs as ament dependencies when BUILD_TESTING is true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ if(BUILD_TESTING)
         find_package(geometry_msgs REQUIRED)
         find_package(ament_cmake_gtest REQUIRED)
 
+        set(TESTING_DEPENDENCIES sensor_msgs geometry_msgs)
+
         ament_add_gtest(rosx_introspection_test
             test/test_parser.cpp
             test/test_ros2.cpp )
@@ -110,7 +112,7 @@ endif(BUILD_TESTING)
 
 if(USING_ROS2)
     ament_export_targets(rosx_introspectionTargets HAS_LIBRARY_TARGET)
-    ament_export_dependencies(ament_index_cpp rosbag2_cpp)
+    ament_export_dependencies(ament_index_cpp rosbag2_cpp ${TESTING_DEPENDENCIES})
     ament_package()
 endif(USING_ROS2)
 


### PR DESCRIPTION
I was trying to build Jazzy from source (long story).  While colcon-building [foxglove_sdk](https://github.com/foxglove/foxglove-sdk) branch `master`, I got these cryptic errors:

```
CMake Error at CMakeLists.txt:124 (add_library):
  Target "foxglove_bridge_component" links to target
  "sensor_msgs::sensor_msgs__rosidl_generator_c" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


CMake Error at CMakeLists.txt:124 (add_library):
  Target "foxglove_bridge_component" links to target
  "sensor_msgs::sensor_msgs__rosidl_typesupport_fastrtps_c" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


CMake Error at CMakeLists.txt:124 (add_library):
  Target "foxglove_bridge_component" links to target
  "sensor_msgs::sensor_msgs__rosidl_generator_cpp" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


CMake Error at CMakeLists.txt:124 (add_library):
  Target "foxglove_bridge_component" links to target
  "sensor_msgs::sensor_msgs__rosidl_typesupport_fastrtps_cpp" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?

(etc)
```

I believe this is because sensor_msgs and geometry_msgs are not ament dependencies when BUILD_TESTING is true.  This patch adds to `ament_export_dependencies` when appropriate.

I'm not sure how widespread this error is occuring (which ROS distros, etc), or if it's related to recent changes in [foxglove-sdk](https://github.com/foxglove/foxglove-sdk)
