### PR TITLE
Fix heap overflow on large strings and false failure on oversized struct arrays

### DIFF
--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -10,6 +10,7 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: rolling
+          OS_CODE_NAME: noble
           ROS_REPO: main
         with:
             package-name: rosx_introspection

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,8 @@ if(BUILD_TESTING)
 
         ament_add_gtest(parser_test
             test/test_parser.cpp
-            test/test_encoding.cpp)
+            test/test_encoding.cpp
+            test/test_msgpack.cpp)
 
         target_link_libraries(parser_test rosx_introspection)
         target_include_directories(parser_test PUBLIC
@@ -129,7 +130,8 @@ if(BUILD_TESTING)
 
         add_executable(parser_test
                 test/test_parser.cpp
-                test/test_encoding.cpp)
+                test/test_encoding.cpp
+                test/test_msgpack.cpp)
 
         target_link_libraries(parser_test rosx_introspection GTest::GTest GTest::Main)
         target_include_directories(parser_test PUBLIC

--- a/python/rosx_introspection_py.cpp
+++ b/python/rosx_introspection_py.cpp
@@ -36,9 +36,12 @@ class Parser {
     // Create span from input data
     RosMsgParser::Span<const uint8_t> msg_span(reinterpret_cast<const uint8_t*>(raw_data.c_str()), raw_data.size());
 
-    if (!parser_.deserialize(msg_span, &flat_msg_, &deserializer_)) {
-      throw std::runtime_error("Failed to parse ROS message");
-    }
+    // deserialize() returns false when oversized arrays were discarded by the
+    // DISCARD_LARGE_ARRAYS policy (e.g. a tf message with >max_array_size
+    // transforms). That is expected behaviour, not an error: the FlatMessage is
+    // still valid (minus the discarded arrays). Genuine failures throw, and the
+    // exception propagates out of this method to Python.
+    parser_.deserialize(msg_span, &flat_msg_, &deserializer_);
 
     RosMsgParser::convertToMsgpack(flat_msg_, output_buffer_);
     return nb::bytes(reinterpret_cast<const char*>(output_buffer_.data()), output_buffer_.size());

--- a/src/msgpack_utils.cpp
+++ b/src/msgpack_utils.cpp
@@ -74,7 +74,15 @@ void convertToMsgpack(const FlatMessage& flat_msg, std::vector<uint8_t>& msgpack
   std::string key_buf;
   for (const auto& [key, num_value] : flat_msg.value) {
     key.toStr(key_buf);
-    resize_if_needed(5 + key_buf.size() + 9);  // max key header + key + max value size
+    // A number packs into at most 9 bytes, but a STRING value can be arbitrarily
+    // large. If we only reserved 9 bytes, pack_string() would write past the
+    // buffer and the trailing resize(offset) would reallocate and zero-fill the
+    // overflowed tail, truncating long strings (~64KB) to NULs.
+    size_t value_capacity = 9;
+    if (num_value.getTypeID() == BuiltinType::STRING) {
+      value_capacity = 5 + num_value.convert<std::string>().size();  // str32 header + bytes
+    }
+    resize_if_needed(5 + key_buf.size() + value_capacity);  // key header + key + value
     offset += msgpack::pack_string(msgpack_data.data() + offset, key_buf);
     offset += pack_variant(num_value, msgpack_data.data() + offset);
   }

--- a/test/test_msgpack.cpp
+++ b/test/test_msgpack.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "rosx_introspection/deserializer.hpp"
+#include "rosx_introspection/msgpack_utils.hpp"
+#include "rosx_introspection/ros_parser.hpp"
+#include "rosx_introspection/serializer.hpp"
+
+using namespace RosMsgParser;
+
+// Regression for the convertToMsgpack() buffer under-reservation bug: string
+// VALUES (unlike numbers) can be arbitrarily large. The loop only reserved 9
+// bytes for the value, so pack_string() overflowed msgpack_data and the trailing
+// resize(offset) reallocated and zero-filled the overflowed tail, truncating any
+// string longer than ~64KB to NULs.
+TEST(Msgpack, LargeStringValueSurvivesConversion)
+{
+  Parser parser("topic", ROSType("test_msgs/BigString"), "string data");
+
+  std::string big(100000, 'x');
+  const std::string tail_marker = "ROSX_TAIL_MARKER_END";
+  big += tail_marker;  // placed beyond the ~64KB truncation boundary
+  ASSERT_GT(big.size(), 64u * 1024u);
+
+  NanoCDR_Serializer enc;
+  enc.serializeString(big);
+  std::vector<uint8_t> buffer(enc.getBufferData(), enc.getBufferData() + enc.getBufferSize());
+
+  FlatMessage flat;
+  NanoCDR_Deserializer deser;
+  parser.deserialize(Span<const uint8_t>(buffer.data(), buffer.size()), &flat, &deser);
+
+  // The decoded FlatMessage value itself is correct (the bug was downstream).
+  ASSERT_EQ(flat.value.size(), 1u);
+  ASSERT_EQ(flat.value[0].second.convert<std::string>(), big);
+
+  std::vector<uint8_t> msgpack_data;
+  convertToMsgpack(flat, msgpack_data);
+
+  // The full string -- including its tail past 64KB -- must survive encoding.
+  std::string_view sv(reinterpret_cast<const char*>(msgpack_data.data()), msgpack_data.size());
+  EXPECT_NE(sv.find(tail_marker), std::string_view::npos)
+      << "string value was truncated by convertToMsgpack";
+}
+
+// Regression for the oversized-struct-array bug: an array of variable-size
+// structs whose length exceeds max_array_size (default 100) must be DISCARDED
+// (DISCARD_LARGE_ARRAYS) without throwing, while the read cursor stays aligned so
+// that fields AFTER the array are still decoded correctly. deserialize() returns
+// false here only to signal "not entirely stored", which must not be treated as a
+// hard failure by callers (the Python binding used to throw on it).
+TEST(Msgpack, OversizedStructArrayIsDiscardedNotFailed)
+{
+  const std::string def =
+      "Item[] items\n"
+      "int32 trailer\n"
+      "================================================================================\n"
+      "MSG: test_msgs/Item\n"
+      "string name\n"
+      "float64 value\n";
+
+  Parser parser("topic", ROSType("test_msgs/Outer"), def);
+
+  const int N = 150;  // > max_array_size (100)
+  NanoCDR_Serializer enc;
+  enc.serializeUInt32(static_cast<uint32_t>(N));
+  for (int i = 0; i < N; ++i)
+  {
+    enc.serializeString("item_" + std::to_string(i));
+    enc.serialize(BuiltinType::FLOAT64, double(i));
+  }
+  enc.serialize(BuiltinType::INT32, int32_t(12345));  // trailer, after the big array
+
+  std::vector<uint8_t> buffer(enc.getBufferData(), enc.getBufferData() + enc.getBufferSize());
+
+  FlatMessage flat;
+  NanoCDR_Deserializer deser;
+  bool complete = true;
+  ASSERT_NO_THROW({
+    complete = parser.deserialize(Span<const uint8_t>(buffer.data(), buffer.size()), &flat, &deser);
+  });
+
+  // false == "some arrays were discarded" (NOT a parse failure).
+  EXPECT_FALSE(complete);
+
+  // Cursor stayed aligned past the 150 discarded structs: the trailer is intact.
+  bool found_trailer = false;
+  for (const auto& [key, value] : flat.value)
+  {
+    if (key.toStdString().find("trailer") != std::string::npos)
+    {
+      EXPECT_EQ(value.convert<int32_t>(), 12345);
+      found_trailer = true;
+    }
+  }
+  EXPECT_TRUE(found_trailer) << "trailer field after the oversized array was lost";
+}


### PR DESCRIPTION
## Summary

Two bugs surfaced while decoding large real-world MCAP messages (a warehouse-robot ROS 2 dataset) through the Python binding. Both are large-data edge cases; normal-sized messages were unaffected, which is why they went unnoticed.

## Bug 1 — `convertToMsgpack()` heap overflow on large string values

`convertToMsgpack()` reserves buffer space per field with `resize_if_needed(5 + key.size() + 9)`, where `9` is the max size of a packed **number**. But a **string** Variant is packed full-length by `pack_string()`. Once a string pushed the output past the buffer's current capacity, `pack_string()` wrote past the end of `msgpack_data`, and the trailing `msgpack_data.resize(offset)` then **reallocated and zero-filled** the overflowed tail.

- **Via the Python binding:** string values larger than ~64 KB came back byte-correct up to the buffer boundary (≈ offset 64639 for a 101 KB field) and then NUL-padded.
- **Standalone:** it corrupts the heap — `double free or corruption (!prev)`, `SIGABRT`.

**Fix:** reserve `5 + value.size()` for `STRING` values. (The `MsgpackMessageWriter::writeString` path already did the equivalent via `ensureCapacity`; only the standalone `convertToMsgpack` used by the binding was affected.)

## Bug 2 — binding treats a discarded large array as a parse failure

`Parser::deserialize()` returns `walkSchema()`'s `state.entire_message_parsed`, which is set `false` whenever an oversized array is **discarded** by the default `DISCARD_LARGE_ARRAYS` policy. That is expected, successful behaviour — the read cursor still walks every element, so the rest of the message decodes correctly.

The nanobind wrapper, however, threw `"Failed to parse ROS message"` on that `false`. As a result, any message containing an array of **structs** longer than `max_array_size` (default 100) failed entirely — e.g. `/tf_static` with 161 `TransformStamped`, or a `nav_msgs/Path` with 2905 `PoseStamped` — while `/tf` with 8 transforms worked.

**Fix:** the binding no longer treats `false` as an error. Genuine failures throw exceptions (e.g. buffer overrun), which still propagate to Python.

## Tests

`test/test_msgpack.cpp` adds two regression tests (registered in both the ament and standalone `parser_test` targets):

- `Msgpack.LargeStringValueSurvivesConversion` — round-trips a >64 KB string field with a marker placed past the truncation boundary. **Against the unpatched code this aborts with `double free or corruption`**; with the fix it passes.
- `Msgpack.OversizedStructArrayIsDiscardedNotFailed` — a 150-element array of `{string, float64}` structs followed by a trailing `int32`. Asserts `deserialize()` does **not** throw, returns `false` (discarded), and the trailing scalar after the discarded array still decodes as `12345` (cursor stayed aligned).

Both pass; the first crashes on the pre-fix build, confirming the regression catch.

## Reproduction context

Found while comparing `rosx_introspection` decode/flatten output against a `rosbags`-based Python path on real MCAP data — field names and values matched on all 41 message types (including custom robot types) except for these two large-data cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
