### PR TITLE
fix(idl): converge DDS @key path handling (in-position keys, key-indexed sequences)

### DIFF
--- a/include/rosx_introspection/idl_parser.hpp
+++ b/include/rosx_introspection/idl_parser.hpp
@@ -9,7 +9,7 @@ namespace RosMsgParser {
 /// Parse a DDS IDL schema string and build a MessageSchema.
 ///
 /// @param topic_name   Name used as the root of the field tree
-/// @param root_type    The message type to use as root (e.g., "AsensusMessaging/ArmState")
+/// @param root_type    The message type to use as root (e.g., "my_pkg/MyMessage")
 /// @param idl_schema   Complete IDL text (all #include'd content must be concatenated)
 /// @return             Populated MessageSchema ready for deserialization
 MessageSchema::Ptr ParseIDL(

--- a/include/rosx_introspection/ros_message.hpp
+++ b/include/rosx_introspection/ros_message.hpp
@@ -100,7 +100,7 @@ std::vector<ROSMessage::Ptr> ParseMessageDefinitions(const std::string& multi_de
 
 MessageSchema::Ptr BuildMessageSchema(const std::string& topic_name, const std::vector<ROSMessage::Ptr>& parsed_msgs);
 
-void CacheFieldTreePaths(FieldTree& tree);
+void CacheFieldTreePaths(FieldTree& tree, const RosMessageLibrary& library);
 
 }  // namespace RosMsgParser
 

--- a/include/rosx_introspection/stringtree_leaf.hpp
+++ b/include/rosx_introspection/stringtree_leaf.hpp
@@ -59,8 +59,9 @@ inline int print_number(char* buffer, uint16_t value) {
 
 namespace RosMsgParser {
 
-/// Fixed-size buffer for @key suffixes (e.g., "[ArmID:3]").
-/// Avoids heap allocation — typical key suffixes are < 48 chars.
+/// Fixed-size buffer for a @key bracket value (e.g., "ArmID:3").
+/// Stores only the bracket *content*; the surrounding "[" "]" are added by the
+/// path renderer. Avoids heap allocation — typical key values are < 48 chars.
 struct KeySuffix {
   char data[48] = {};
   uint8_t len = 0;
@@ -86,8 +87,9 @@ struct KeySuffix {
  * It provides the pointer to the node and a list of numbers that represent
  * the index that corresponds to the placeholder "#".
  */
-/// A field may be reached through several @key levels, so suffixes accumulate
-/// (e.g. an outer "[ArmID:3]" and an inner "[J1]"). They are appended in order.
+/// A field may be reached through several @key levels (e.g. an outer "ArmID:3"
+/// and an inner "J1"). Each value fills one key bracket placeholder in the
+/// node's cached path, in order.
 using KeySuffixes = SmallVector<KeySuffix, 2>;
 
 struct FieldLeaf {

--- a/include/rosx_introspection/tree.hpp
+++ b/include/rosx_introspection/tree.hpp
@@ -105,6 +105,15 @@ class TreeNode {
     return _bracket_count;
   }
 
+  /// Bitmask: bit i is set when the i-th bracket placeholder of cachedPath()
+  /// is filled with a @key value rather than a numeric array index.
+  uint8_t bracketKeyMask() const {
+    return _bracket_key_mask;
+  }
+  void setBracketKeyMask(uint8_t mask) {
+    _bracket_key_mask = mask;
+  }
+
   void setCachedPath(std::string path) {
     _cached_path = std::move(path);
     _bracket_count = 0;
@@ -128,6 +137,7 @@ class TreeNode {
   std::string _cached_path;
   uint16_t _bracket_offsets[max_brackets] = {};
   uint8_t _bracket_count = 0;
+  uint8_t _bracket_key_mask = 0;
 };
 
 template <typename T>

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -888,7 +888,7 @@ MessageSchema::Ptr ParseIDL(const std::string& topic_name, const ROSType& root_t
 
   recursiveTreeCreator(*schema->root_msg, schema->field_tree.root());
 
-  CacheFieldTreePaths(schema->field_tree);
+  CacheFieldTreePaths(schema->field_tree, schema->msg_library);
 
   return schema;
 }

--- a/src/ros_message.cpp
+++ b/src/ros_message.cpp
@@ -184,41 +184,85 @@ MessageSchema::Ptr BuildMessageSchema(const std::string& topic_name, const std::
 
   recursiveTreeCreator(schema->root_msg, schema->field_tree.root());
 
-  CacheFieldTreePaths(schema->field_tree);
+  CacheFieldTreePaths(schema->field_tree, schema->msg_library);
 
   return schema;
 }
 
-static void cachePathsImpl(FieldTreeNode* node, const std::string& parent_path, bool is_root) {
+// Number of @key members declared by the struct that is the type of `field`.
+// Returns 0 for builtins, enums, or any type not resolvable to a struct.
+static int structKeyCount(const ROSField* field, const RosMessageLibrary& library) {
+  if (!field || field->type().isBuiltin()) {
+    return 0;
+  }
+  auto msg = field->getMessagePtr(library);
+  if (!msg) {
+    return 0;
+  }
+  int count = 0;
+  for (const auto& f : msg->fields()) {
+    if (!f.isConstant() && f.isKey()) {
+      count++;
+    }
+  }
+  return count;
+}
+
+// Build each node's cached path with "[]" bracket placeholders, and a parallel
+// bitmask marking which placeholders carry a @key value (vs a numeric array
+// index). A @key contributes one bracket right after the node of the struct
+// that owns it; for a sequence of keyed structs the key replaces the array
+// index, so the numeric index is suppressed.
+static void cachePathsImpl(FieldTreeNode* node, const std::string& parent_path, uint8_t parent_mask,
+                           uint8_t parent_brackets, bool is_root, const RosMessageLibrary& library) {
   const ROSField* field = node->value();
   std::string path;
+  uint8_t mask = parent_mask;
+  uint8_t bracket_count = parent_brackets;
+
+  auto addBrackets = [&](int n, bool is_key) {
+    for (int i = 0; i < n; i++) {
+      path += "[]";
+      if (is_key && bracket_count < 8) {
+        mask |= static_cast<uint8_t>(1u << bracket_count);
+      }
+      bracket_count++;
+    }
+  };
+
   if (field) {
+    const int num_keys = structKeyCount(field, library);
     if (is_root) {
       path = field->name();
+      addBrackets(num_keys, /*is_key=*/true);
     } else {
       path.reserve(parent_path.size() + 1 + field->name().size() + 12);
       path.append(parent_path);
       path += '/';
       path += field->name();
       if (field->isArray()) {
-        size_t num_brackets = field->arrayDimensions().size();
-        if (num_brackets < 2) {
-          num_brackets = 1;
+        if (num_keys > 0) {
+          // Sequence of keyed structs: the key takes the place of the index.
+          addBrackets(num_keys, /*is_key=*/true);
+        } else {
+          size_t dims = field->arrayDimensions().size();
+          addBrackets(dims < 2 ? 1 : static_cast<int>(dims), /*is_key=*/false);
         }
-        for (size_t b = 0; b < num_brackets; b++) {
-          path += "[]";
-        }
+      } else if (num_keys > 0) {
+        // Keyed struct reached as a plain (non-array) field.
+        addBrackets(num_keys, /*is_key=*/true);
       }
     }
   }
   node->setCachedPath(path);
+  node->setBracketKeyMask(mask);
   for (auto& child : node->children()) {
-    cachePathsImpl(&child, path, false);
+    cachePathsImpl(&child, path, mask, bracket_count, false, library);
   }
 }
 
-void CacheFieldTreePaths(FieldTree& tree) {
-  cachePathsImpl(tree.root(), "", true);
+void CacheFieldTreePaths(FieldTree& tree, const RosMessageLibrary& library) {
+  cachePathsImpl(tree.root(), "", 0, 0, true, library);
 }
 
 }  // namespace RosMsgParser

--- a/src/ros_parser.cpp
+++ b/src/ros_parser.cpp
@@ -58,13 +58,31 @@ static const std::string* enumNameForDDSCompatValue(const EnumDefinition* enum_d
   return nullptr;
 }
 
-// Append a @key suffix to the leaf. A field can be reached through several @key
-// levels (e.g. ".../value[ArmID:3][J1]"), so suffixes accumulate rather than
-// overwrite. They are rolled back per scope by resizing key_suffixes.
+// Push a @key bracket value (content only; the renderer adds the surrounding
+// "[" "]"). A field can be reached through several @key levels (e.g. an outer
+// "ArmID:3" and an inner "J1"); the values accumulate in order and are rolled
+// back per scope by resizing key_suffixes.
 static void pushKeySuffix(FieldLeaf& leaf, const char* data, int len) {
   KeySuffix ks;
   ks.assign(data, static_cast<size_t>(len));
   leaf.key_suffixes.push_back(ks);
+}
+
+// True if `field`'s type is a struct that declares at least one @key member.
+static bool structHasKey(const ROSField& field, const RosMessageLibrary& library) {
+  if (field.type().isBuiltin()) {
+    return false;
+  }
+  auto msg = field.getMessagePtr(library);
+  if (!msg) {
+    return false;
+  }
+  for (const auto& f : msg->fields()) {
+    if (!f.isConstant() && f.isKey()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Parser::Parser(const std::string& topic_name, const ROSType& msg_type, const std::string& definition,
@@ -136,22 +154,20 @@ void Parser::walkImpl(const ROSMessage* msg, FieldLeaf& leaf, bool store, WalkSt
     if (field.type().typeID() == STRING) {
       std::string str;
       deserializer->deserializeString(str);
-      int len = snprintf(buf, sizeof(buf), "[%s]", str.c_str());
-      pushKeySuffix(leaf, buf, len);
+      pushKeySuffix(leaf, str.data(), static_cast<int>(str.size()));
     } else if (field.getEnum() != nullptr) {
       Variant var = deserializer->deserialize(INT32);
       int32_t enum_int = var.convert<int32_t>();
       const std::string* enum_name = enumNameForDDSCompatValue(field.getEnum(), enum_int);
       if (enum_name) {
-        int len = snprintf(buf, sizeof(buf), "[%s]", enum_name->c_str());
-        pushKeySuffix(leaf, buf, len);
+        pushKeySuffix(leaf, enum_name->data(), static_cast<int>(enum_name->size()));
       } else {
-        int len = snprintf(buf, sizeof(buf), "[%d]", enum_int);
+        int len = snprintf(buf, sizeof(buf), "%d", enum_int);
         pushKeySuffix(leaf, buf, len);
       }
     } else if (field.type().isBuiltin()) {
       Variant var = deserializer->deserialize(field.type().typeID());
-      int len = snprintf(buf, sizeof(buf), "[%s:%ld]", field.name().c_str(), (long)var.convert<int64_t>());
+      int len = snprintf(buf, sizeof(buf), "%s:%ld", field.name().c_str(), (long)var.convert<int64_t>());
       pushKeySuffix(leaf, buf, len);
     }
   }
@@ -207,7 +223,13 @@ void Parser::walkImpl(const ROSMessage* msg, FieldLeaf& leaf, bool store, WalkSt
     const auto& dims = field.arrayDimensions();
     const bool is_multidim = dims.size() > 1;
 
-    if (is_array) {
+    // A sequence/array of keyed structs identifies its elements by @key value
+    // rather than by position, so the numeric index is suppressed: the
+    // element's @key fills the bracket instead (see cachePathsImpl).
+    const bool elem_keyed = is_array && structHasKey(field, _schema->msg_library);
+    const bool push_index = is_array && !elem_keyed;
+
+    if (push_index) {
       if (is_multidim) {
         // Push one index entry per dimension
         for (size_t d = 0; d < dims.size(); d++) {
@@ -242,10 +264,15 @@ void Parser::walkImpl(const ROSMessage* msg, FieldLeaf& leaf, bool store, WalkSt
     } else {
       bool DO_STORE_ARRAY = DO_STORE;
       for (int i = 0; i < array_size; i++) {
+        // Roll back @key brackets pushed by the previous keyed element so they
+        // do not accumulate across iterations of the sequence.
+        if (elem_keyed) {
+          leaf.key_suffixes.resize(saved_key_suffix_size);
+        }
         if (DO_STORE_ARRAY && i >= static_cast<int32_t>(_max_array_size)) {
           DO_STORE_ARRAY = false;
         }
-        if (is_array && DO_STORE_ARRAY) {
+        if (push_index && DO_STORE_ARRAY) {
           if (is_multidim) {
             // Compute multi-dimensional indices from flat index
             int flat = i;

--- a/src/stringtree_leaf.cpp
+++ b/src/stringtree_leaf.cpp
@@ -26,11 +26,16 @@
 namespace RosMsgParser {
 
 // Helper: fill bracket placeholders in a cached path template using segment memcpy.
+// Each placeholder is filled with either a @key value (key_mask bit set, pulled
+// in order from key_suffixes) or a numeric array index (pulled in order from
+// index_array). The two sources advance on independent cursors.
 static size_t fillBrackets(char* buf, const char* tmpl, size_t tmpl_size,
-                           const uint16_t* offsets, uint8_t num_brackets,
-                           const SmallVector<uint16_t, 4>& index_array) {
+                           const uint16_t* offsets, uint8_t num_brackets, uint8_t key_mask,
+                           const SmallVector<uint16_t, 4>& index_array, const KeySuffixes& key_suffixes) {
   size_t out_off = 0;
   size_t src_off = 0;
+  size_t idx_cursor = 0;
+  size_t key_cursor = 0;
 
   for (uint8_t i = 0; i < num_brackets; i++) {
     size_t seg_len = offsets[i] - src_off;
@@ -38,8 +43,14 @@ static size_t fillBrackets(char* buf, const char* tmpl, size_t tmpl_size,
     out_off += seg_len;
 
     buf[out_off++] = '[';
-    if (i < index_array.size()) {
-      out_off += print_number(buf + out_off, index_array[i]);
+    if (key_mask & (1u << i)) {
+      if (key_cursor < key_suffixes.size()) {
+        const auto& ks = key_suffixes[key_cursor++];
+        std::memcpy(buf + out_off, ks.data, ks.len);
+        out_off += ks.len;
+      }
+    } else if (idx_cursor < index_array.size()) {
+      out_off += print_number(buf + out_off, index_array[idx_cursor++]);
     }
     buf[out_off++] = ']';
     src_off = offsets[i] + 2;
@@ -62,13 +73,6 @@ static size_t totalKeyBytes(const KeySuffixes& key_suffixes) {
   return n;
 }
 
-static void appendKeySuffixes(char* out, size_t& offset, const KeySuffixes& key_suffixes) {
-  for (const auto& ks : key_suffixes) {
-    std::memcpy(out + offset, ks.data, ks.len);
-    offset += ks.len;
-  }
-}
-
 // FieldLeaf::toStr — uses precomputed path template + bracket offset table.
 void FieldLeaf::toStr(std::string& out) const {
   if (!node) {
@@ -77,20 +81,19 @@ void FieldLeaf::toStr(std::string& out) const {
   }
   const auto& tmpl = node->cachedPath();
   const uint8_t num_brackets = node->bracketCount();
-  const size_t key_bytes = totalKeyBytes(key_suffixes);
 
-  if (num_brackets == 0 && key_bytes == 0) {
+  if (num_brackets == 0) {
     out = tmpl;
     return;
   }
 
-  size_t extra = num_brackets * 5 + key_bytes;
+  // Upper bound: each bracket adds "[]" plus its content (<= 5 digits for an
+  // index, or the key value bytes).
+  size_t extra = num_brackets * 7 + totalKeyBytes(key_suffixes);
   out.resize(tmpl.size() + extra);
 
-  size_t offset = fillBrackets(out.data(), tmpl.data(), tmpl.size(),
-                               node->bracketOffsets(), num_brackets, index_array);
-
-  appendKeySuffixes(out.data(), offset, key_suffixes);
+  size_t offset = fillBrackets(out.data(), tmpl.data(), tmpl.size(), node->bracketOffsets(), num_brackets,
+                               node->bracketKeyMask(), index_array, key_suffixes);
   out.resize(offset);
 }
 
@@ -108,20 +111,17 @@ void FieldsVector::toStr(std::string& out) const {
 
   const auto& tmpl = _node->cachedPath();
   const uint8_t num_brackets = _node->bracketCount();
-  const size_t key_bytes = totalKeyBytes(key_suffixes);
 
-  if (num_brackets == 0 && key_bytes == 0) {
+  if (num_brackets == 0) {
     out = tmpl;
     return;
   }
 
-  size_t extra = num_brackets * 5 + key_bytes;
+  size_t extra = num_brackets * 7 + totalKeyBytes(key_suffixes);
   out.resize(tmpl.size() + extra);
 
-  size_t offset = fillBrackets(out.data(), tmpl.data(), tmpl.size(),
-                               _node->bracketOffsets(), num_brackets, index_array);
-
-  appendKeySuffixes(out.data(), offset, key_suffixes);
+  size_t offset = fillBrackets(out.data(), tmpl.data(), tmpl.size(), _node->bracketOffsets(), num_brackets,
+                               _node->bracketKeyMask(), index_array, key_suffixes);
   out.resize(offset);
 }
 

--- a/test/test_data/mcap/ims_msgs__RoboticsInputs.idl
+++ b/test/test_data/mcap/ims_msgs__RoboticsInputs.idl
@@ -1,4 +1,4 @@
-module AsensusMessaging {
+module CommonTypes {
     typedef unsigned long long ArmIDType;
 };
 
@@ -110,7 +110,7 @@ module ims_msgs {
     };
 };
 
-module AsensusMessaging {
+module CommonTypes {
     struct Wrench {
         double Fx;
         double Fy;
@@ -121,7 +121,7 @@ module AsensusMessaging {
     };
 };
 
-module AsensusMessaging {
+module CommonTypes {
     struct Vector3D {
         float X;
         float Y;
@@ -131,9 +131,9 @@ module AsensusMessaging {
 
 module ims_msgs {
     struct SixDofForceSensorInputs {
-        AsensusMessaging::Wrench Forces;
-        AsensusMessaging::Vector3D LinearAcceleration;
-        AsensusMessaging::Vector3D AngularVelocity;
+        CommonTypes::Wrench Forces;
+        CommonTypes::Vector3D LinearAcceleration;
+        CommonTypes::Vector3D AngularVelocity;
         unsigned long StatusCode;
         unsigned long SampleCounter;
         ims_msgs::DeviceIOErrorCode ErrorCode;
@@ -143,7 +143,7 @@ module ims_msgs {
 
 module ims_msgs {
     struct RoboticsInputs {
-        @key AsensusMessaging::ArmIDType ArmID;
+        @key CommonTypes::ArmIDType ArmID;
         sequence<ims_msgs::MotorFeedback,100> MotorData;
         sequence<ims_msgs::JointFeedback,100> JointData;
         ims_msgs::SixDofForceSensorInputs SixDofData;

--- a/test/test_idl.cpp
+++ b/test/test_idl.cpp
@@ -930,10 +930,10 @@ TEST(IDLDeserialize, KeyPathSuffix) {
 
 // Test real-world IDL parsing (integration test)
 static const char* REAL_WORLD_IDL = R"(
-#ifndef ASENSUS_DATA_TYPES
-#define ASENSUS_DATA_TYPES
+#ifndef COMMON_DATA_TYPES
+#define COMMON_DATA_TYPES
 
-module AsensusMessaging {
+module CommonTypes {
 
   typedef uint64 ArmIDType;
   typedef string<36> UserID;
@@ -1024,7 +1024,7 @@ module AsensusMessaging {
 )";
 
 // ============================================================
-// Cross-parser comparison: rosx_introspection vs dds-parser
+// Comparison against a reference DDS decode of a real recorded message
 // ============================================================
 
 static std::string readFile(const std::string& path) {
@@ -1045,7 +1045,7 @@ static std::vector<uint8_t> readBinaryFile(const std::string& path) {
   return std::vector<uint8_t>(std::istreambuf_iterator<char>(f), {});
 }
 
-// Convert a Variant to a type:value string matching dds-parser's format
+// Convert a Variant to a "type:value" string matching the reference output format
 static std::string variantToTypeValue(const Variant& v) {
   std::ostringstream oss;
   switch (v.getTypeID()) {
@@ -1152,13 +1152,13 @@ TEST(IDLComparison, McapRoboticsInputs) {
     }
   }
 
-  // NOTE: Known differences between rosx_introspection and dds-parser output:
-  // 1. Key handling: dds-parser uses enum key names as array indices (e.g., [IDS1]),
-  //    rosx_introspection uses numeric indices with key suffix (e.g., [0]...[J1])
-  // 2. Enum fields: dds-parser emits both /enum_str (string) and /enum_val (int),
-  //    rosx_introspection emits only the int value
-  // These are known divergences that will be addressed incrementally.
-  // For now, just verify we deserialized a reasonable number of values.
+  // NOTE: @key paths now match the reference output exactly (the key value
+  // fills the bracket in position, and for a sequence of keyed structs it
+  // replaces the numeric index). One representation difference remains: for an
+  // enum field the reference emits both an "/enum_str" (string) and an
+  // "/enum_val" (int) entry, whereas this parser emits only the int value at
+  // the field path. That makes this parser produce fewer entries, so we check
+  // the count is in a sane range rather than comparing line-by-line.
   EXPECT_GT(actual_lines.size(), 200u)
       << "Expected at least 200 values from RoboticsInputs message";
   EXPECT_LE(actual_lines.size(), expected_lines.size())
@@ -1166,26 +1166,26 @@ TEST(IDLComparison, McapRoboticsInputs) {
 }
 
 TEST(IDLParser, RealWorldDataTypes) {
-  auto schema = ParseIDL("topic", ROSType("AsensusMessaging/ArmState"), REAL_WORLD_IDL);
+  auto schema = ParseIDL("topic", ROSType("CommonTypes/ArmState"), REAL_WORLD_IDL);
 
   ASSERT_NE(schema, nullptr);
 
   // Check structs
-  EXPECT_NE(schema->msg_library.find(ROSType("AsensusMessaging/Pose")), schema->msg_library.end());
-  EXPECT_NE(schema->msg_library.find(ROSType("AsensusMessaging/Wrench")), schema->msg_library.end());
-  EXPECT_NE(schema->msg_library.find(ROSType("AsensusMessaging/Vector3D")), schema->msg_library.end());
-  EXPECT_NE(schema->msg_library.find(ROSType("AsensusMessaging/ArmPosition")), schema->msg_library.end());
-  EXPECT_NE(schema->msg_library.find(ROSType("AsensusMessaging/TransformationFrame")), schema->msg_library.end());
+  EXPECT_NE(schema->msg_library.find(ROSType("CommonTypes/Pose")), schema->msg_library.end());
+  EXPECT_NE(schema->msg_library.find(ROSType("CommonTypes/Wrench")), schema->msg_library.end());
+  EXPECT_NE(schema->msg_library.find(ROSType("CommonTypes/Vector3D")), schema->msg_library.end());
+  EXPECT_NE(schema->msg_library.find(ROSType("CommonTypes/ArmPosition")), schema->msg_library.end());
+  EXPECT_NE(schema->msg_library.find(ROSType("CommonTypes/TransformationFrame")), schema->msg_library.end());
 
   // Check enums
   EXPECT_EQ(schema->enum_library.size(), 2u);  // FrameID and ErrorEnum
-  auto frame_it = schema->enum_library.find(ROSType("AsensusMessaging/FrameID"));
+  auto frame_it = schema->enum_library.find(ROSType("CommonTypes/FrameID"));
   ASSERT_NE(frame_it, schema->enum_library.end());
   EXPECT_EQ(frame_it->second.values.size(), 10u);
   EXPECT_EQ(frame_it->second.values[0].name, "BaseLink");
   EXPECT_EQ(frame_it->second.values[0].value, 0);
 
-  auto error_it = schema->enum_library.find(ROSType("AsensusMessaging/ErrorEnum"));
+  auto error_it = schema->enum_library.find(ROSType("CommonTypes/ErrorEnum"));
   ASSERT_NE(error_it, schema->enum_library.end());
   EXPECT_EQ(error_it->second.values[1].name, "ArmBegin");
   EXPECT_EQ(error_it->second.values[1].value, 0x1000);
@@ -1799,4 +1799,258 @@ TEST(IDLDeserialize, MultipleKeyFields) {
   EXPECT_NE(path.find("[arm_id:3]"), std::string::npos) << "path was: " << path;
   EXPECT_NE(path.find("[J2]"), std::string::npos) << "path was: " << path;
   EXPECT_EQ(flat.value[0].second.convert<double>(), 2.5);
+}
+
+// ============================================================
+// @key path handling for OMG IDL / DDS keyed types.
+//
+// A @key member is consumed first and rendered as a "[...]" bracket placed
+// immediately after the node of the struct that owns it (NOT appended at the
+// end of the path). For a sequence of keyed structs the key takes the place
+// of the numeric array index, so elements are identified by key rather than
+// by position. These tests assert full, exact paths (not substring matches).
+//
+//   - integral key -> "[fieldName:value]"
+//   - enum key     -> "[EnumName]"
+//   - string key   -> "[value]"
+// ============================================================
+
+static std::vector<std::string> AllPaths(const FlatMessage& flat) {
+  std::vector<std::string> out;
+  out.reserve(flat.value.size());
+  for (const auto& [leaf, value] : flat.value) {
+    out.push_back(leaf.toStdString());
+  }
+  return out;
+}
+
+// --- A top-level integral @key renders right after the topic node ---------
+static const char* KEY_TOPLEVEL_IDL = R"(
+module M {
+  struct KeyedMsg {
+    @key uint32 instance_id;
+    float64 value;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, TopLevelIntegralKeyPosition) {
+  Parser parser("topic", ROSType("M/KeyedMsg"), KEY_TOPLEVEL_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serialize(UINT32, Variant(uint32_t(7)));  // @key instance_id = 7
+  serializer.serialize(FLOAT64, Variant(42.0));         // value
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 1u);
+  EXPECT_EQ(flat.value[0].first.toStdString(), "topic[instance_id:7]/value");
+  EXPECT_DOUBLE_EQ(flat.value[0].second.convert<double>(), 42.0);
+}
+
+// --- Multiple top-level @key fields, both right after the topic node -------
+static const char* KEY_MULTI_IDL = R"(
+module M {
+  enum Joint { J1, J2 };
+  struct Cmd {
+    @key uint32 arm_id;
+    @key Joint joint;
+    float64 target;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, MultipleTopLevelKeysPosition) {
+  Parser parser("cmd", ROSType("M/Cmd"), KEY_MULTI_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serialize(UINT32, Variant(uint32_t(3)));   // @key arm_id = 3
+  serializer.serialize(INT32, Variant(int32_t(1)));     // @key joint  = J2 (ordinal 1)
+  serializer.serialize(FLOAT64, Variant(double(2.5)));  // target
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 1u);
+  EXPECT_EQ(flat.value[0].first.toStdString(), "cmd[arm_id:3][J2]/target");
+  EXPECT_DOUBLE_EQ(flat.value[0].second.convert<double>(), 2.5);
+}
+
+// --- An enum @key renders as its NAME, in position ------------------------
+static const char* KEY_ENUM_IDL = R"(
+module M {
+  enum Status {
+    @value(100) Idle,
+    @value(200) Active
+  };
+  struct Item {
+    @key Status status;
+    int32 data;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, EnumKeyPosition) {
+  Parser parser("item", ROSType("M/Item"), KEY_ENUM_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serialize(INT32, Variant(int32_t(1)));   // @key status: wire ordinal 1 -> Active
+  serializer.serialize(INT32, Variant(int32_t(42)));  // data
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 1u);
+  EXPECT_EQ(flat.value[0].first.toStdString(), "item[Active]/data");
+  EXPECT_EQ(flat.value[0].second.convert<int32_t>(), 42);
+}
+
+// --- A string @key renders as "[value]" in position -----------------------
+static const char* KEY_STRING_IDL = R"(
+module M {
+  struct Named {
+    @key string<32> name;
+    int32 v;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, StringKeyPosition) {
+  Parser parser("k", ROSType("M/Named"), KEY_STRING_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serializeString("foo");                 // @key name = "foo"
+  serializer.serialize(INT32, Variant(int32_t(5)));  // v
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 1u);
+  EXPECT_EQ(flat.value[0].first.toStdString(), "k[foo]/v");
+  EXPECT_EQ(flat.value[0].second.convert<int32_t>(), 5);
+}
+
+// --- A @key on a nested (non-array) struct field renders after that field --
+static const char* KEY_NESTED_PLAIN_IDL = R"(
+module M {
+  struct Inner {
+    @key uint32 id;
+    float64 v;
+  };
+  struct Outer {
+    Inner inner;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, KeyOnNestedPlainStruct) {
+  Parser parser("o", ROSType("M/Outer"), KEY_NESTED_PLAIN_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serialize(UINT32, Variant(uint32_t(9)));  // inner.@key id = 9
+  serializer.serialize(FLOAT64, Variant(1.5));          // inner.v
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 1u);
+  EXPECT_EQ(flat.value[0].first.toStdString(), "o/inner[id:9]/v");
+  EXPECT_DOUBLE_EQ(flat.value[0].second.convert<double>(), 1.5);
+}
+
+// --- THE CORE CASE: a sequence of keyed structs uses the key in place of the
+//     numeric array index (e.g. /moves[J1]/..., /moves[J2]/...) -------------
+static const char* KEY_SEQUENCE_IDL = R"(
+module M {
+  enum Joint { J1, J2, J3 };
+  struct MoveTarget {
+    float64 value;
+  };
+  struct AxisMove {
+    @key Joint joint;
+    MoveTarget target;
+  };
+  struct SyncMove {
+    sequence<AxisMove, 30> moves;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, KeyedSequenceUsesKeyNotIndex) {
+  Parser parser("sync", ROSType("M/SyncMove"), KEY_SEQUENCE_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serializeUInt32(2);                     // sequence length = 2
+  serializer.serialize(INT32, Variant(int32_t(0)));  // moves[0].@key joint = J1
+  serializer.serialize(FLOAT64, Variant(1.0));        // moves[0].target.value
+  serializer.serialize(INT32, Variant(int32_t(1)));  // moves[1].@key joint = J2
+  serializer.serialize(FLOAT64, Variant(2.0));        // moves[1].target.value
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 2u);
+  auto paths = AllPaths(flat);
+  EXPECT_EQ(paths[0], "sync/moves[J1]/target/value");
+  EXPECT_EQ(paths[1], "sync/moves[J2]/target/value");
+  EXPECT_DOUBLE_EQ(flat.value[0].second.convert<double>(), 1.0);
+  EXPECT_DOUBLE_EQ(flat.value[1].second.convert<double>(), 2.0);
+}
+
+// --- Regression guard: a sequence of NON-keyed structs still uses [i] ------
+static const char* NONKEY_SEQUENCE_IDL = R"(
+module M {
+  struct Inner {
+    float64 a;
+  };
+  struct Plain {
+    sequence<Inner, 10> items;
+  };
+};
+)";
+
+TEST(IDLKeyConvergence, NonKeyedSequenceUsesIndex) {
+  Parser parser("p", ROSType("M/Plain"), NONKEY_SEQUENCE_IDL, DDS_IDL);
+
+  NanoCDR_Serializer serializer;
+  serializer.reset();
+  serializer.serializeUInt32(2);                // sequence length = 2
+  serializer.serialize(FLOAT64, Variant(1.0));  // items[0].a
+  serializer.serialize(FLOAT64, Variant(2.0));  // items[1].a
+
+  std::vector<uint8_t> buffer(serializer.getBufferData(),
+                              serializer.getBufferData() + serializer.getBufferSize());
+  FlatMessage flat;
+  NanoCDR_Deserializer deserializer;
+  ASSERT_TRUE(parser.deserialize(Span<const uint8_t>(buffer), &flat, &deserializer));
+
+  ASSERT_EQ(flat.value.size(), 2u);
+  auto paths = AllPaths(flat);
+  EXPECT_EQ(paths[0], "p/items[0]/a");
+  EXPECT_EQ(paths[1], "p/items[1]/a");
 }


### PR DESCRIPTION
## Problem

DDS `@key` members were rendered incorrectly in field paths:

- The key value was appended at the **end** of the path instead of being placed at the keyed struct's position — `topic/value[instance_id:7]` instead of `topic[instance_id:7]/value`.
- A `sequence<>` of keyed structs was always indexed by **numeric position**, so the same logical instance could land under a different `[i]` between samples — unstable series names in PlotJuggler.
- Key brackets were only rolled back at field granularity, so keys **accumulated** across sequence elements (`moves[1]/.../value[J1][J2]`).

## Fix

`@key` values are now first-class bracket placeholders in the cached-path renderer:

- a key produces a `[...]` bracket immediately after the node of the struct that owns it;
- a sequence of keyed structs uses the key **in place of** the numeric index (`moves[J1]/...`, `moves[J2]/...`), so elements are identified by key rather than by position;
- key brackets are rolled back per array element.

Bracket-value formats: integral `[field:value]`, enum `[EnumName]`, string `[value]`.

### Before / after

| Case | Before | After |
|---|---|---|
| Top-level key | `topic/value[instance_id:7]` | `topic[instance_id:7]/value` |
| Multiple keys | `cmd/target[arm_id:3][J2]` | `cmd[arm_id:3][J2]/target` |
| Keyed sequence | `sync/moves[0]/target/value[J1]` | `sync/moves[J1]/target/value` |
| 2nd seq element | `sync/moves[1]/target/value[J1][J2]` | `sync/moves[J2]/target/value` |

### Implementation

- `TreeNode` gains a per-bracket key bitmask (`_bracket_key_mask`).
- `cachePathsImpl` is key-aware: it emits key brackets after a keyed struct's node and suppresses the numeric index for keyed sequences (`CacheFieldTreePaths` now takes the message library).
- `fillBrackets` interleaves key values and numeric indices via two cursors.
- `walkImpl` suppresses the index for keyed sequences and rolls back key brackets per element. The numeric-index hot path is unchanged.

## Tests

New `IDLKeyConvergence.*` suite asserts **exact** full paths for: top-level integral key, multiple top-level keys, enum key, string key, key on a nested struct, the keyed-sequence case, and a non-keyed-sequence regression guard. Existing key tests and the recorded-message comparison test still pass. Full `ctest` passes (`parser_test`, `idl_parser_test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
