### PR TITLE
ci: add Lyrical to CI matrix and README badges

### DIFF
--- a/.github/workflows/lyrical.yaml
+++ b/.github/workflows/lyrical.yaml
@@ -1,0 +1,15 @@
+name: Lyrical
+
+on: [push, pull_request]
+
+jobs:
+  industrial_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: lyrical
+          ROS_REPO: main
+        with:
+            package-name: rosx_introspection

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Humble](https://github.com/facontidavide/rosx_introspection/actions/workflows/humble.yaml/badge.svg)](https://github.com/facontidavide/rosx_introspection/actions/workflows/humble.yaml)
 [![Jazzy](https://github.com/facontidavide/rosx_introspection/actions/workflows/jazzy.yaml/badge.svg)](https://github.com/facontidavide/rosx_introspection/actions/workflows/jazzy.yaml)
 [![Kilted](https://github.com/facontidavide/rosx_introspection/actions/workflows/kilted.yaml/badge.svg)](https://github.com/facontidavide/rosx_introspection/actions/workflows/kilted.yaml)
+[![Lyrical](https://github.com/facontidavide/rosx_introspection/actions/workflows/lyrical.yaml/badge.svg)](https://github.com/facontidavide/rosx_introspection/actions/workflows/lyrical.yaml)
 [![Rolling](https://github.com/facontidavide/rosx_introspection/actions/workflows/rolling.yaml/badge.svg)](https://github.com/facontidavide/rosx_introspection/actions/workflows/rolling.yaml)
 
 A runtime message parser and introspection library for ROS. It can deserialize any ROS message


### PR DESCRIPTION
## Summary
- Add a per-distro `industrial_ci` workflow for **ROS 2 Lyrical** (`.github/workflows/lyrical.yaml`), mirroring the other released-distro workflows.
- Add the matching **Lyrical** status badge to the README (between Kilted and Rolling).

Lyrical is `active` in `ros/rosdistro` (targets Ubuntu `resolute`). Mirrors `kilted.yaml` with no `OS_CODE_NAME` pin — industrial_ci derives the target OS from rosdistro. `rolling.yaml`'s existing `OS_CODE_NAME: noble` pin is intentionally left untouched.

This brings the CI matrix in line with the ROS 2 distro scope (humble, jazzy, kilted, lyrical, rolling) ahead of the 3.1.x RoboStack release.

## Test plan
- CI runs the new **Lyrical** workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)